### PR TITLE
fix: replace 'fix' by 'chore' and include imported repository URL in PR title

### DIFF
--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -1062,7 +1062,7 @@ func (o *ImportOptions) addSourceConfigPullRequest(gitURL string, gitKind string
 		OutDir:            "",
 		BranchName:        "",
 		PullRequestNumber: 0,
-		CommitTitle:       "fix: import repository",
+		CommitTitle:       fmt.Sprintf("chore: import repository %s", gitURL),
 		CommitMessage:     "",
 		ScmClient:         o.ScmFactory.ScmClient,
 		BatchMode:         o.BatchMode,


### PR DESCRIPTION
Replaced "fix" by "chore", as importing a repository isn't really a fix of the environment.

Related: jenkins-x/jx-promote#83