### PR TITLE
fix: replace 'fix' by 'chore' and include imported repository URL in PR title

### DIFF
--- a/pkg/cmd/importcmd/import.go
+++ b/pkg/cmd/importcmd/import.go
@@ -932,7 +932,7 @@ func (o *ImportOptions) DiscoverGit() error {
 		if o.BatchMode {
 			message = "Initial import"
 		} else {
-			message, err = o.Input.PickValue("Commit message: ", "fix: initial import", true, "Please enter the initial git commit message")
+			message, err = o.Input.PickValue("Commit message: ", "chore: initial import", true, "Please enter the initial git commit message")
 			if err != nil {
 				return errors.Wrapf(err, "failed to confirm commit message")
 			}

--- a/pkg/cmd/importcmd/source_config_pr.go
+++ b/pkg/cmd/importcmd/source_config_pr.go
@@ -1,6 +1,7 @@
 package importcmd
 
 import (
+	"fmt"
 	"path/filepath"
 
 	"github.com/jenkins-x/go-scm/scm"
@@ -49,7 +50,7 @@ func (o *ImportOptions) addSourceConfigPullRequest(gitURL string, gitKind string
 		OutDir:            "",
 		BranchName:        "",
 		PullRequestNumber: 0,
-		CommitTitle:       "fix: import repository",
+		CommitTitle:       fmt.Sprintf("chore: import repository %s", gitURL),
 		CommitMessage:     "",
 		ScmClient:         o.ScmFactory.ScmClient,
 		BatchMode:         o.BatchMode,


### PR DESCRIPTION
Replaced "fix" by "chore", as importing a repository isn't really a fix of the environment.

Related: [jenkins-x/jx-promote#83](https://github.com/jenkins-x/jx-promote/pull/83)