### PR TITLE
fix: properly pass the git token to private quickstarts if the domains match

### DIFF
--- a/pkg/cmd/root/domain_cmp.go
+++ b/pkg/cmd/root/domain_cmp.go
@@ -1,0 +1,32 @@
+package root
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// SameRootDomain returns true if the same last 2 paths of the domain are the same. e.g. *.github.com or *.mygitserver.com
+func SameRootDomain(u1 string, u2 string) (bool, error) {
+	url1, err := url.Parse(u1)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse URL %s", u1)
+	}
+	url2, err := url.Parse(u2)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to parse URL %s", u2)
+	}
+	domains1 := strings.Split(url1.Host, ".")
+	domains2 := strings.Split(url2.Host, ".")
+	if len(domains1) < 2 || len(domains2) < 2 {
+		return false, nil
+	}
+	if domains1[len(domains1)-1] != domains2[len(domains2)-1] {
+		return false, nil
+	}
+	if domains1[len(domains1)-2] != domains2[len(domains2)-2] {
+		return false, nil
+	}
+	return true, nil
+}

--- a/pkg/cmd/root/domain_cmp_test.go
+++ b/pkg/cmd/root/domain_cmp_test.go
@@ -1,0 +1,48 @@
+package root_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/jenkins-x/jx-project/pkg/cmd/root"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDomainCompare(t *testing.T) {
+	testCases := []struct {
+		expected  bool
+		expectErr bool
+		u1        string
+		u2        string
+	}{
+		{
+			u1:       "https://github.ibm.com/foo/bar",
+			u2:       "https://codeload.github.com/cheese",
+			expected: false,
+		},
+		{
+			u1:       "https://github.com/foo/bar",
+			u2:       "https://codeload.github.com/cheese",
+			expected: true,
+		},
+		{
+			u1:       "https://github.ibm.com/foo/bar",
+			u2:       "https://codeload.github.ibm.com/cheese",
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		message := fmt.Sprintf("comparing %s and %s", tc.u1, tc.u2)
+		actual, err := root.SameRootDomain(tc.u1, tc.u2)
+		if tc.expectErr {
+			require.Error(t, err, "should fail for "+message)
+			t.Logf("got expected error for %s of %s\n", message, err.Error())
+			continue
+		}
+		require.NoError(t, err, "failed "+message)
+		assert.Equal(t, tc.expected, actual, message)
+		t.Logf("%s got %v\n", message, actual)
+	}
+}


### PR DESCRIPTION
so we can use, say, github enterprise and quickstarts hosted on a private GHE server