### PR TITLE
fix: latest jx-promote requires labels on the PullRequestDetails

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/denormal/go-gitignore v0.0.0-20180713143441-75ce8f3e513c
 	github.com/google/uuid v1.1.4
 	github.com/jbrukh/bayesian v0.0.0-20200318221351-d726b684ca4a // indirect
-	github.com/jenkins-x/go-scm v1.5.203
+	github.com/jenkins-x/go-scm v1.5.204
 	github.com/jenkins-x/jx-api/v4 v4.0.17
 	github.com/jenkins-x/jx-gitops v0.0.512
 	github.com/jenkins-x/jx-helpers/v3 v3.0.49
@@ -33,7 +33,7 @@ require (
 )
 
 replace (
-	github.com/jenkins-x/go-scm => github.com/jenkins-x/go-scm v1.5.203
+	github.com/jenkins-x/go-scm => github.com/jenkins-x/go-scm v1.5.204
 	github.com/tektoncd/pipeline => github.com/jenkins-x/pipeline v0.3.2-0.20201002150609-ca0741e5d19a
 	k8s.io/api => k8s.io/api v0.19.4
 	k8s.io/apimachinery => k8s.io/apimachinery v0.19.4

--- a/go.sum
+++ b/go.sum
@@ -773,6 +773,8 @@ github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/U
 github.com/jehiah/go-strftime v0.0.0-20171201141054-1d33003b3869/go.mod h1:cJ6Cj7dQo+O6GJNiMx+Pa94qKj+TG8ONdKHgMNIyyag=
 github.com/jenkins-x/go-scm v1.5.203 h1:Z1/YwKgLmoR6nn4TDhN0KvQrTJ8h0eG97GL0AVIDU1w=
 github.com/jenkins-x/go-scm v1.5.203/go.mod h1:pTp8HHrCEVGs24H/8Cy+X/CDXFlKv9VC6zmrXBYNkfE=
+github.com/jenkins-x/go-scm v1.5.204 h1:BdV5TEaUqCR0roImbz9qh2qFdQ7mmg86zAih3rweN5s=
+github.com/jenkins-x/go-scm v1.5.204/go.mod h1:pTp8HHrCEVGs24H/8Cy+X/CDXFlKv9VC6zmrXBYNkfE=
 github.com/jenkins-x/jx-api/v4 v4.0.11/go.mod h1:3n+xwDoSuALVUSlIUj8nK105k7hqP5HoTh7cch/FScc=
 github.com/jenkins-x/jx-api/v4 v4.0.14/go.mod h1:3n+xwDoSuALVUSlIUj8nK105k7hqP5HoTh7cch/FScc=
 github.com/jenkins-x/jx-api/v4 v4.0.16/go.mod h1:e98SpJGhOodGShusrGhMqSzRsyZbVsPjWGpEQ2hC0Mk=
@@ -781,6 +783,7 @@ github.com/jenkins-x/jx-api/v4 v4.0.17/go.mod h1:e98SpJGhOodGShusrGhMqSzRsyZbVsP
 github.com/jenkins-x/jx-gitops v0.0.508/go.mod h1:bRaDoaK5x2g78qFYpfdx8TCW/3tk0COo6bXW5kUSe54=
 github.com/jenkins-x/jx-gitops v0.0.511 h1:F/Ldno2ibM3ZdTQucfAeuiHLAvBGGmTMXOv0CEwOm1M=
 github.com/jenkins-x/jx-gitops v0.0.511/go.mod h1:/l2olTb/QOjKptMqdbHneULn1J2yJNS/Jp//lnNRP8M=
+github.com/jenkins-x/jx-gitops v0.0.512 h1:RycuF2rDW4aVf5cKLF48uKgiUjEXal+HdI4lAoeEhhs=
 github.com/jenkins-x/jx-gitops v0.0.512/go.mod h1:/l2olTb/QOjKptMqdbHneULn1J2yJNS/Jp//lnNRP8M=
 github.com/jenkins-x/jx-helpers/v3 v3.0.45/go.mod h1:sLCICGle5SWzgG2qLSscPom7LNZJzJhYXPL+Um9BMPI=
 github.com/jenkins-x/jx-helpers/v3 v3.0.48/go.mod h1:BDyjFXYs3QecOwD3YjkblbeJ8OK1ht8lfp5XYcbCAkU=

--- a/pkg/cmd/importcmd/source_config_pr.go
+++ b/pkg/cmd/importcmd/source_config_pr.go
@@ -59,7 +59,7 @@ func (o *ImportOptions) addSourceConfigPullRequest(gitURL string, gitKind string
 		BatchMode:         o.BatchMode,
 		UseGitHubOAuth:    false,
 		Fork:              false,
-		Labels:            []string{"env/dev"},
+		//Labels:            []string{"env/dev"},
 	}
 
 	pro.Function = func() error {
@@ -89,7 +89,13 @@ func (o *ImportOptions) addSourceConfigPullRequest(gitURL string, gitKind string
 		log.Logger().Infof("defaulting the user name to %s so we can create a PullRequest", pro.Username)
 	}
 	*/
-	prDetails := &scm.PullRequest{}
+	prDetails := &scm.PullRequest{
+		Labels: []*scm.Label{
+			{
+				Name: "env/dev",
+			},
+		},
+	}
 
 	pr, err := pro.Create(devGitURL, "", prDetails, false)
 	if err != nil {


### PR DESCRIPTION
so that we properly add the `env/dev`label for imports and quickstarts